### PR TITLE
Indexing nested maps and array fields.

### DIFF
--- a/test/clucy/test/core.clj
+++ b/test/clucy/test/core.clj
@@ -91,4 +91,18 @@
              {:name {:boost 0.0}})
            (with-meta {:planet "Earth" :designer "Slartibartfast"}
              {:name {:boost 1.0}}))
-      (is (= "Earth" (:planet (first (search i "Slartibartfast" 2))))))))
+      (is (= "Earth" (:planet (first (search i "Slartibartfast" 2)))))))
+  (testing "Array fields"
+           (let [i (memory-index)]
+             (add i {:name "Paul"
+                     :likes ["bread" "onions"]})
+             (is (= ["bread" "onions"] (:likes (first 
+                                                 (search i "Paul" 10)))))))
+  (testing "Nested maps"
+           (let [i (memory-index)]
+             (add i {:book {:author {:first-name "Dostoyevsky"
+                                     :last-name "Fyodor"}
+                            :title "Crime and Punishment"}})
+             (is (= {:first-name "Dostoyevsky"
+                     :last-name "Fyodor"}
+                    (:author (:book (first (search i "Crime and Punishment" 10)))))))))


### PR DESCRIPTION
Enables ability to index maps of this form

``` clojure
(def an-index (memory-index))
(add an-index
 {:single "value"
 :values ["first" "second" "third"]
 :nested {:map {:level "n"}}})
```

For searching nested maps use dotted version of the field name in query, example:

``` clojure
(search an-index "nested.map.level:n" 1)
```

will return the above indexed map.
